### PR TITLE
set proper indexer token for sandbox

### DIFF
--- a/src/utils/nodeConfig.ts
+++ b/src/utils/nodeConfig.ts
@@ -63,7 +63,7 @@ export function getNodes(): NodeConnectionParams[] {
         indexer: {
             url: 'http://localhost',
             port: '8980',
-            token: ''
+            token: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         }
     },
         {


### PR DESCRIPTION
when person clicks the sandbox, he has to type in the token manually

without the token the dappflow does not work on sandbox